### PR TITLE
use a common bytes.Buffer for decrypt io.

### DIFF
--- a/decrypt.go
+++ b/decrypt.go
@@ -11,17 +11,17 @@ const (
 	syncByte = uint8(71) //0x47
 )
 
-func decryptAES128(crypted, key, iv []byte) ([]byte, error) {
+func decryptAES128(data, key, iv []byte) error {
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	blockSize := block.BlockSize()
 	blockMode := cipher.NewCBCDecrypter(block, iv[:blockSize])
-	origData := make([]byte, len(crypted))
-	blockMode.CryptBlocks(origData, crypted)
-	origData = pkcs5UnPadding(origData)
-	return origData, nil
+	blockMode.CryptBlocks(data, data)
+	c := pkcs5UnPadding(data)
+	copy(data, c)
+	return nil
 }
 
 func pkcs5Padding(cipherText []byte, blockSize int) []byte {

--- a/hlsdl_test.go
+++ b/hlsdl_test.go
@@ -1,6 +1,7 @@
 package hlsdl
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"testing"
@@ -20,7 +21,9 @@ func TestDescrypt(t *testing.T) {
 	}
 	defer os.Remove(seg.Path)
 
-	if _, err := hlsDl.decrypt(seg); err != nil {
+	var buf bytes.Buffer
+
+	if _, err := hlsDl.decrypt(seg, &buf); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -31,5 +34,46 @@ func TestDownload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Fatalf("downloaded: %s", filepath)
 	os.RemoveAll(filepath)
+}
+
+func BenchmarkDecrypt(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	segs, err := parseHlsSegments("https://cdn.theoplayer.com/video/big_buck_bunny_encrypted/stream-800/index.m3u8", nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	hlsDl := New("https://cdn.theoplayer.com/video/big_buck_bunny_encrypted/stream-800/index.m3u8", nil, "./download", "", 2, false)
+	seg := segs[0]
+	seg.Path = fmt.Sprintf("%s/seg%d.ts", hlsDl.dir, seg.SeqId)
+	if err := hlsDl.downloadSegment(seg); err != nil {
+		b.Fatal(err)
+	}
+	defer os.Remove(seg.Path)
+
+	var buf bytes.Buffer
+
+	if _, err := hlsDl.decrypt(seg, &buf); err != nil {
+		b.Fatal(err)
+	}
+
+	b.StopTimer()
+}
+
+func BenchmarkDownload(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	hlsDl := New("https://cdn.theoplayer.com/video/big_buck_bunny_encrypted/stream-800/index.m3u8", nil, "./download", "", 2, false)
+	filepath, err := hlsDl.Download()
+	if err != nil {
+		b.Fatal(err)
+	}
+	os.RemoveAll(filepath)
+
+	b.StopTimer()
 }

--- a/recorder.go
+++ b/recorder.go
@@ -103,7 +103,7 @@ func (r *Recorder) downloadSegment(segment *Segment) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		data, err = decryptAES128(data, key, iv)
+		err = decryptAES128(data, key, iv)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
we can make use of the fact that cipher.CryptBlocks() can operate on a single slice (instead of copying from src to dst it can operate in place)

from crypt.CryptBlocks() docs
> CryptBlocks encrypts or decrypts a number of blocks. The length of src must be a multiple of the block size. Dst and src must overlap entirely or not at all.

Added a test to benchmark memory usage